### PR TITLE
v0.8.0

### DIFF
--- a/.versions
+++ b/.versions
@@ -14,8 +14,9 @@ meteor@1.1.6
 minimongo@1.0.8
 mongo@1.1.0
 ordered-dict@1.0.3
-ostrio:neo4jdriver@0.2.13
-ostrio:neo4jreactivity@0.7.3
+ostrio:minimongo-extensions@1.0.1
+ostrio:neo4jdriver@0.2.14
+ostrio:neo4jreactivity@0.8.0
 random@1.0.3
 reactive-var@1.0.5
 retry@1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+Changelog
+=========
+
+### [0.8.0](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.8.0)
+
+* Fix issue #43
+* Add __latency compensation__ when using data as mini-mongo (mini-neo4j) representation
+* [BREAKING CHANGE] `Meteor.neo4j.publish()` and `Meteor.neo4j.subscribe()` now accepts 4 parameters only. Use `publish(name, func, [onSubscribe])` and `subscribe(name, [opts], link)` methods, which is available on object returned from `Meteor.neo4j.collection(name)`
+
+### [0.7.3](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.7.3)
+
+* Minor code refactoring
+
+### [0.7.2](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.7.2)
+
+* `mongo` package dependency suggested by @Neobii
+
+### [0.7.1](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.7.1)
+
+* Minor enhancements
+* Solve issue with standard Neo4j Authorisation
+* Neo4jDriver update to v0.2.12
+
+### [0.7.0](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.7.0)
+
+Added:
+* Meteor.neo4j.collection - Create Mongo like neo4j collection
+* Meteor.neo4j. publish - Publish Mongo like neo4j collection
+* Meteor.neo4j. subscribe - Subscribe on Mongo like neo4j collection
+
+Also:
+* Code rewritten to coffee
+* Better in-code docs
+* Better documentation in readme.md
+
+### [0.6.0](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.6.0)
+
+* Overall improvements
+* Fix issue with dotted keys in Mongo >= 2.6.0:
+  - Now if you expect to retrieve key field.key, it will be available as field_key
+
+### [0.5.3](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.5.3)
+
+* Use Meteor.bindEnvironment instead of Fibers to require npm-package
+* Remove unneeded packages
+
+### [0.5.0](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.5.0)
+
+* Fix issue with aggregation
+* Unify get() method for reactive data on Server and Client
+* Unify data returned via callback on Server and Client
+* Almost fully rewritten code
+* Library now initialized as solid object
+* Fix issue with allow/deny rules
+* Improved parseSensitivities method
+* Updated docs
+* Driver was well tested on different Cypher queries
+
+### [0.4.3](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.4.3)
+
+* Add neo4j.connectionURL property to change Neo4j URL on the fly
+* Better docs
+
+### [0.4.2](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.4.2)
+
+* Add jshint globals and rules
+* Code is refactored
+* Better Sensitivities look up
+* Better Cypher mapping
+* Better caching (for write queries)
+* UPD due to Meteor updates
+* Add missed dependencies
+
+### [0.3.6](https://github.com/VeliovGroup/ostrio-Neo4jreactivity/releases/tag/v0.3.6)
+
+* Bug fix for mapping parameters in Cypher query, we've replaced it with our own function

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Veliov Group Inc., ostr.io, Dmitriy Aristarkhovich, Dmitry A.
+Copyright (c) 2014 Veliov Group Inc., ostr.io, dr.dimitru, Dmitriy Aristarkhovich, Dmitry A.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ostrio:neo4jreactivity_collection.coffee
+++ b/ostrio:neo4jreactivity_collection.coffee
@@ -34,9 +34,10 @@ if Meteor.isServer
       false
 
   Meteor.publish 'Neo4jCacheCollection', (uids) ->
-    Meteor.neo4j.cacheCollection.find uid: '$in': uids
+    Meteor.neo4j.cacheCollection.find 
+      uid: 
+        '$in': uids
 
 if Meteor.isClient
   Tracker.autorun ->
     Meteor.subscribe 'Neo4jCacheCollection', Meteor.neo4j.uids.get()
-

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'ostrio:neo4jreactivity',
   summary: 'Meteor.js Neo4j database reactivity layer',
-  version: '0.7.3',
+  version: '0.8.0',
   git: 'https://github.com/VeliovGroup/ostrio-Neo4jreactivity.git'
 });
 
@@ -9,9 +9,9 @@ Package.onUse(function(api) {
   api.versionsFrom('1.0');
   api.addFiles(['ostrio:neo4jreactivity_driver.coffee', 'ostrio:neo4jreactivity_collection.coffee'], ['client', 'server']);
   api.addFiles('ostrio:neo4jreactivity_methods.coffee', 'server');
-  api.use(['mongo', 'underscore', 'sha', 'coffeescript'], ['client', 'server']);
+  api.use(['mongo', 'check', 'underscore', 'sha', 'coffeescript', 'random', 'ostrio:minimongo-extensions@1.0.1'], ['client', 'server']);
   api.use(['tracker', 'reactive-var'], 'client');
-  api.use('ostrio:neo4jdriver@0.2.13', 'server');
+  api.use('ostrio:neo4jdriver@0.2.14', 'server');
 });
 
 Npm.depends({

--- a/readme.md
+++ b/readme.md
@@ -213,9 +213,11 @@ friends.subscribe 'allFriends', {userId: Meteor.userId()}, 'friends'
 ```
 
 ###### Template helper [*Client*]
+```coffeescript
 Template.friendsNamesList.helpers
   friends: ()->
     friends.find({})
+```
 
 ###### In Template:
 ```html

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ API
   - `name` {*String*} - Name of publish function. Please use same name in publish/subscription
   - `func` {*Function*} - Function wich returns Cypher query string
   - `onSubscribe` {*Function*} - Callback which runs after each subscription
-  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L85)
+  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/16c710c2ffac58691beb295a0c5f06c143cc9945/leaderboard.js#L76)
 
 ## Client
  * `Meteor.neo4j.call(name, [[opts], [link].. ], callback)` - Call server Neo4j method
@@ -111,7 +111,7 @@ Call for method registered via `Meteor.neo4j.methods`.
   - `opts` {*Object*} - A map of parameters for the Cypher query.
   - `callback` {*Function*} - Returns `error` and `data` arguments.
   - Returns {*Object*} - With `cursor` and reactive `get()` method
-  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/16c710c2ffac58691beb295a0c5f06c143cc9945/leaderboard.js#L76)
+  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/eabeaa853f634af59295680c5c7cf8dd9ac5437c/leaderboard.js#L39)
  * `Meteor.neo4j.subscribe(collectionName, name, [opts], [link])`
   - `collectionName` {*String*} - Collection name of method function
   - `name` {*String*} - Name of subscribe function. Please use same name in publish/subscription

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Several Notes
 If you have many different queries to Neo4j database on production environment, you will probably want to avoid `Neo4jCache` collection overwhelming. Make build-in JavaScript-based TTL utility is useless, so we are suggest to take a look on [TTL indexes](http://docs.mongodb.org/manual/core/index-ttl/) and [expire data tutorial](http://docs.mongodb.org/manual/tutorial/expire-data/). `Neo4jCache` records has `created` {*Date*} field, so in our case it will be something like:
 ```javascript
 /* run this at mongodb shell */
-db.eventlog.createIndex({ 
+db.Neo4jCache.createIndex({ 
   created: 1 
 },{ 
   expireAfterSeconds: 3600 * 24 /* 3600 * 24 = 1 day */
@@ -43,8 +43,8 @@ API
  * `Meteor.neo4j.allowClientQuery`
   - `allowClientQuery` {*Boolean*} - Allow/Deny Cypher queries execution on the client side
  * `Meteor.neo4j.connectionURL = 'http://user:pass@localhost:7474';` 
-  - Set connection URL within login and password to Neo4j DataBase
-  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/16c710c2ffac58691beb295a0c5f06c143cc9945/leaderboard.js#L74)
+  - Set connection URL, uncluding login and password to Neo4j DataBase
+  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/lib/neo4j.js#L4)
  * `Meteor.neo4j.rules.write` - Array of strings with Cypher write operators
  * `Meteor.neo4j.rules.read` - Array of strings with Cypher read operators
  * `Meteor.neo4j.set.allow([rules])` - Set allowed Cypher operators for client side
@@ -52,20 +52,25 @@ API
  * `Meteor.neo4j.set.deny([rules])` - Set denied Cypher operators for client side
   - `rules` {*[String]*} - Array of Cyphper query operators Strings
   - For example to deny all write queries, use: `Meteor.neo4j.set.deny(Meteor.neo4j.rules.write)`
+  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/lib/neo4j.js#L6)
  * `Meteor.neo4j.query(query, opts, callback)` - __Returns__ reactive {Object} with `get()` method.
-  - `query` {*Strin*g} - Name of publish function. Please use same name in collection/publish/subscription
+  - `query` {*String*} - Name of publish function. Please use same name in collection/publish/subscription
   - `opts` {*Object*} - A map of parameters for the Cypher query.
   - `callback` {*Function*} - Callback which runs after each subscription
     * `error` {*Object*|*null*} - Error of Neo4j Cypher query execution or null
     * `data` {*Object*|*null*} - Data or null from Neo4j Cypher query execution
   - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/eabeaa853f634af59295680c5c7cf8dd9ac5437c/leaderboard.js#L9)
  * `Meteor.neo4j.collection(name)`
-  - `name` {*String*} - Name of collection. `users = Meteor.neo4j.collection 'Users'`
+  - `name` {*String*} - Name of collection. 
+  ```coffeescript
+  users = Meteor.neo4j.collection 'Users'
+  ```
   - This method returns collection with next methods:
     * `publish(name, func, [onSubscribe])` [**Server**] - Publish dataset to client. 
       - `name` {*String*} - Publish/Subscription name
       - `func` {*Function*} - Function which returns Cypher query
       - `onSubscibe` {*Function*} - Callback function called right after data is published
+      - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L85)
     ```coffeescript
     users.publish 'currentUser', () ->
       return 'MATCH (user:User {_id: {_id}}) RETURN user;'
@@ -74,18 +79,19 @@ API
       - `name` {*String*} - Publish/Subscription name
       - `opts` {*Object*|*null*} - A map of parameters for the Cypher query
       - `link` {*String*} - Sub object name, to link as MobgoDB row(s). See example below:
+      - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L15)
     ```coffeescript
     users.subscribe 'currentUser', _id: Meteor.userId(), 'user'
     ```
-    * `find([selector], [options])` - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/master/leaderboard.js#L23). Use to search thru returned data from Neo4j
+    * `find([selector], [options])` - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L20). Use to search thru returned data from Neo4j
       - `fetch()` - Use to fetch Cursor data
     * `findOne([selector], [options])`
-    * `insert(doc, [callback])`
-    * `update(selector, modifier, [options], [callback])`
+    * `insert(doc, [callback])` - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L52)
+    * `update(selector, modifier, [options], [callback])` - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L39)
     * `upsert(selector, modifier, [options], [callback])`
-    * `remove(selector, [callback])`
-    * __Note__: All `selector`s and `doc` support `__labels` property, - use it to set Cypher label on insert or searching data
-    * [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/master/leaderboard.js#L10)
+    * `remove(selector, [callback])` - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L76)
+    * __Note__: All `selector`s and `doc` support `__labels` property, - use it to set Cypher label on insert or searching data, see [this example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L55)
+    * [Collection() example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/master/leaderboard.js#L10)
 
 ## Server
  * `Meteor.neo4j.methods(object)` - Create server Cypher queries
@@ -96,22 +102,23 @@ API
   - `name` {*String*} - Name of publish function. Please use same name in publish/subscription
   - `func` {*Function*} - Function wich returns Cypher query string
   - `onSubscribe` {*Function*} - Callback which runs after each subscription
-  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/16c710c2ffac58691beb295a0c5f06c143cc9945/leaderboard.js#L76)
+  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/a6b467f43ccf20f39189e10b5d521fe12b4a55a2/leaderboard.js#L85)
 
 ## Client
  * `Meteor.neo4j.call(name, [[opts], [link].. ], callback)` - Call server Neo4j method
 Call for method registered via `Meteor.neo4j.methods`.
   - `name` {*String*} - Name of method function
   - `opts` {*Object*} - A map of parameters for the Cypher query.
-  - `callback` {*Function*} - Returns `error` and `data` arguments. Data has `get()` method to get reactive data
-  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/eabeaa853f634af59295680c5c7cf8dd9ac5437c/leaderboard.js#L30)
+  - `callback` {*Function*} - Returns `error` and `data` arguments.
+  - Returns {*Object*} - With `cursor` and reactive `get()` method
+  - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/16c710c2ffac58691beb295a0c5f06c143cc9945/leaderboard.js#L76)
  * `Meteor.neo4j.subscribe(collectionName, name, [opts], [link])`
   - `collectionName` {*String*} - Collection name of method function
   - `name` {*String*} - Name of subscribe function. Please use same name in publish/subscription
   - `opts` {*Object*} - A map of parameters for the Cypher query.
   - `link` {*String*} - Sub object name, to link as MobgoDB row(s)
   - [Example](https://github.com/VeliovGroup/Meteor-Leaderboard-Neo4j/blob/16c710c2ffac58691beb295a0c5f06c143cc9945/leaderboard.js#L15)
-  - __Note__: Wrap `Meteor.neo4j.subscribe()` to `Tracker.autorun()`
+  - __Note__: Wrap `Meteor.neo4j.subscribe()` into `Tracker.autorun()`
 
 ----------
 ### Predefined Cypher Operators:
@@ -189,38 +196,33 @@ MATCH (user:User {perms: 'guest'}) SET user.something = 2
 Usage examples:
 ==========
 #### As collection and publish/subscribe
-###### Create collection [Isomorphic]
+###### Create collection [*Isomorphic*]
 ```coffeescript
-#CoffeeScript
-Meteor.neo4j.methods 
-    getUsersFriends: () ->
-        return  'MATCH (a:User {_id: {userId}})-[relation:friends]->(b:User) ' +
-                'OPTIONAL MATCH (b:User)-[subrelation:friends]->() ' +
-                'RETURN relation, subrelation, b._id AS b_id, b'
+friends = Meteor.neo4j.collection 'friends'
 ```
 
-###### In Helper
+###### Publish data [*Server*]
 ```coffeescript
-#CoffeeScript
+friends.publish 'allFriends', () ->
+  return "MATCH (user {_id: {userId}})-[:FriendOf]->(friends) RETURN friends"
+```
+
+###### Subscribe on this data [*Client*]
+```coffeescript
+friends.subscribe 'allFriends', {userId: Meteor.userId()}, 'friends'
+```
+
+###### Template helper [*Client*]
 Template.friendsNamesList.helpers
-    userFriends: () ->
-
-        Meteor.neo4j.call 'getUsersFriends', {userId: '12345'}, (error, data) ->
-            if error
-                 #handle error here
-                 throw new Meteor.error '500', 'Something goes wrong here', error.toString()
-            else
-                Session.set 'currenUserFriends', data
-
-        return Session.get 'currentUserFriens'
-```
+  friends: ()->
+    friends.find({})
 
 ###### In Template:
 ```html
 <template name="friendsNamesList">
     <ul>
-        {{#each userFriends.b}}
-           <li>{{b.name}}</li>
+        {{#each friends}}
+           <li>{{name}}</li>
         {{/each}}
     </ul>
 </template>
@@ -231,9 +233,7 @@ Template.friendsNamesList.helpers
 #CoffeeScript
 Meteor.neo4j.methods 
     getUsersFriends: () ->
-        return  'MATCH (a:User {_id: {userId}})-[relation:friends]->(b:User) ' +
-                'OPTIONAL MATCH (b:User)-[subrelation:friends]->() ' +
-                'RETURN relation, subrelation, b._id AS b_id, b'
+        return  "MATCH (user {_id: {userId}})-[:FriendOf]->(friends) RETURN friends"
 ```
 
 ###### In Helper
@@ -241,14 +241,10 @@ Meteor.neo4j.methods
 #CoffeeScript
 Template.friendsNamesList.helpers
     userFriends: () ->
-
-        Meteor.neo4j.call 'getUsersFriends', {userId: '12345'}, (error, data) ->
-            if error
-                 #handle error here
-                 throw new Meteor.error '500', 'Something goes wrong here', error.toString()
+        Meteor.neo4j.call 'getUsersFriends', {userId: Meteor.userId()}, (error, data) ->
+            throw new Meteor.error '500', 'Something goes wrong here', error.toString() if error
             else
-                Session.set 'currenUserFriends', data
-
+              Session.set 'currenUserFriends', data
         return Session.get 'currentUserFriens'
 ```
 
@@ -256,8 +252,8 @@ Template.friendsNamesList.helpers
 ```html
 <template name="friendsNamesList">
     <ul>
-        {{#each userFriends.b}}
-           <li>{{b.name}}</li>
+        {{#each userFriends.friends}}
+           <li>{{name}}</li>
         {{/each}}
     </ul>
 </template>
@@ -321,9 +317,9 @@ Testing & Dev usage
 Understanding the package
 ===========
 After installing `ostrio:neo4jreactivity` package - you will have next variables:
- - `Meteor.Neo4j;` - **[Server]** GraphDatabase object from node-neo4j npm package. Use to connect to other Neo4j servers.
- - `Meteor.N4JDB;` - **[Server]** GraphDatabase instance connected to Neo4j server. Use to run Cypher queries directly in Neo4j DB, without any reactivity
- - `Meteor.neo4j;` - **[Isomorphic]** Neo4jReactivity Driver object
+ - `Meteor.Neo4j;` - [*Server*] GraphDatabase object from node-neo4j npm package. Use to connect to other Neo4j servers.
+ - `Meteor.N4JDB;` - [*Server*] GraphDatabase instance connected to Neo4j server. Use to run Cypher queries directly in Neo4j DB, without any reactivity
+ - `Meteor.neo4j;` - [*Isomorphic*] Neo4jReactivity Driver object
 
 ###### Meteor.Neo4j;
 ```javascript


### PR DESCRIPTION
* Fix issue #43
* Add __latency compensation__ when using data as mini-mongo (mini-neo4j) representation
* [BREAKING CHANGE] `Meteor.neo4j.publish()` and `Meteor.neo4j.subscribe()` now accepts 4 parameters only. Use `publish(name, func, [onSubscribe])` and `subscribe(name, [opts], link)` methods, which is available on object returned from `Meteor.neo4j.collection(name)`